### PR TITLE
Add Power Automate / Workflows Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ func main() {
 - **Telegram** - Bot API with multiple chat support
 - **Email (SMTP)** - Full SMTP support with TLS/STARTTLS
 - **Webhook/JSON** - Generic HTTP webhooks with custom templates
-- **Microsoft Teams** - Enterprise messaging with adaptive cards
+- **Microsoft Teams** - Enterprise messaging with adaptive cards (includes Power Automate / Workflows support)
 - **Mattermost** - Open-source team collaboration with API v4
 - **PagerDuty** - Incident management with Events API v2 (US/EU regions)
 - **Opsgenie** - Atlassian's incident management and alerting (US/EU regions)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ func main() {
 - **Desktop Notifications** - Cross-platform desktop notifications (macOS, Windows, Linux)
 - **Gotify** - Self-hosted push notifications
 - **Ntfy** - Simple HTTP push notifications with priority levels
+- **Bark** - iOS push notifications with custom icons and sounds
 
 ### 🚧 Coming Soon
 - AWS SNS

--- a/USAGE.md
+++ b/USAGE.md
@@ -652,6 +652,78 @@ desktop://?image=/path/to/image.png
 - Support for custom sounds and images
 - Graceful fallbacks when notification tools are unavailable
 
+### Bark
+
+iOS push notification service for sending custom notifications to your iPhone via the Bark app.
+
+**URL Formats:**
+```
+# HTTP
+bark://devicekey@api.day.app/
+bark://devicekey@bark.example.com:8080/
+
+# HTTPS (secure)
+barks://devicekey@api.day.app/
+barks://devicekey@bark.example.com:8443/
+
+# With icon support (v1.9.5+)
+bark://devicekey@api.day.app/?icon=https://example.com/icon.png
+
+# With all parameters
+bark://devicekey@api.day.app/?icon=https://example.com/icon.png&sound=alarm&badge=5&url=https://example.com&category=news&group=alerts
+```
+
+**Query Parameters:**
+- `icon=url` - Custom icon URL (v1.9.5+)
+- `sound=name` - Sound name (e.g., alarm, bell, chime)
+- `badge=int` - Badge count to display on app icon
+- `url=url` - URL to open when notification is tapped
+- `category=string` - Notification category for grouping
+- `group=string` - Notification group for organization
+
+**Features:**
+- iOS push notifications via Bark app
+- Custom icon URLs (new in v1.9.5)
+- Custom sounds and badges
+- Action URLs for tappable notifications
+- Category and group organization
+- Self-hosted server support
+- HTTP and HTTPS support
+
+**Example Usage:**
+```go
+app := apprise.New()
+
+// Basic notification to official Bark server
+app.Add("bark://your-device-key@api.day.app/")
+
+// With custom icon
+app.Add("bark://your-device-key@api.day.app/?icon=https://example.com/logo.png")
+
+// Self-hosted with HTTPS and custom sound
+app.Add("barks://your-device-key@bark.myserver.com/?sound=alarm&badge=3")
+
+// Full featured with action URL
+app.Add("bark://your-device-key@api.day.app/?icon=https://example.com/icon.png&sound=bell&badge=1&url=https://example.com/article&category=news")
+
+app.Notify("Alert", "Server CPU usage high!", apprise.NotifyTypeWarning)
+```
+
+**Bark Setup:**
+1. Install Bark app from iOS App Store
+2. Open app and get your device key
+3. Use official server (api.day.app) or set up your own Bark server
+4. Configure notifications using your device key
+
+**Supported Sounds:**
+- alarm, anticipate, bell, birdsong, bloom
+- calypso, chime, choo, descent, electronic
+- fanfare, glass, gotosleep, healthnotification
+- horn, ladder, mailsent, minuet, multiwayinvitation
+- newmail, newsflash, noir, paymentsuccess
+- shake, sherwoodforest, silence, spell, suspense
+- telegraph, tiptoes, typewriters, update
+
 ### Gotify
 
 Self-hosted push notification server for sending messages to devices and applications.

--- a/USAGE.md
+++ b/USAGE.md
@@ -174,7 +174,7 @@ webhook://api.example.com/notify?method=PUT&content_type=text/plain
 
 ### Microsoft Teams
 
-Enterprise messaging with rich card formatting and theme colors.
+Enterprise messaging with rich card formatting and theme colors, including support for Microsoft Power Automate and Workflows.
 
 **URL Formats:**
 ```
@@ -189,6 +189,11 @@ msteams://token_a/token_b/token_c
 
 # With options
 msteams://team_name/token_a/token_b/token_c?image=no
+
+# Power Automate / Workflows format
+powerautomate://prod-01.eastus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke?params
+workflows://prod-02.westus.logic.azure.com:443/workflows/def456/triggers/manual/paths/invoke
+msflow://prod-03.centralus.logic.azure.com/workflows/ghi789/triggers/manual/paths/invoke
 ```
 
 **Query Parameters:**
@@ -200,6 +205,32 @@ msteams://team_name/token_a/token_b/token_c?image=no
 - Activity images for visual context
 - Support for all Teams webhook versions
 - Markdown text formatting support
+- **Power Automate / Workflows integration** (new in v1.9.5-1)
+- Microsoft Flow support (legacy)
+
+**Power Automate / Workflows:**
+
+Microsoft Power Automate (formerly Flow) and Workflows use Azure Logic Apps webhooks that accept the same MessageCard format as Teams. Use the `powerautomate://`, `workflows://`, or `msflow://` URL schemes with your Logic Apps webhook URL.
+
+```go
+// Power Automate example
+app.Add("powerautomate://prod-01.eastus.logic.azure.com/workflows/abc123def456/triggers/manual/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=xyz789")
+
+// Workflows example
+app.Add("workflows://prod-02.westus.logic.azure.com:443/workflows/def456/triggers/manual/paths/invoke")
+
+// MS Flow (legacy) example
+app.Add("msflow://prod-03.centralus.logic.azure.com/workflows/ghi789/triggers/manual/paths/invoke")
+
+app.Notify("Automation Alert", "Workflow triggered successfully", apprise.NotifyTypeSuccess)
+```
+
+**Getting Your Power Automate Webhook URL:**
+1. Create a new Flow/Workflow in Power Automate
+2. Add a "When a HTTP request is received" trigger
+3. Save the Flow to generate the webhook URL
+4. Copy the full webhook URL (e.g., `https://prod-01.eastus.logic.azure.com/workflows/.../`)
+5. Use it with the `powerautomate://` scheme (remove `https://` and use the scheme instead)
 
 ### Mattermost
 

--- a/apprise/apprise.go
+++ b/apprise/apprise.go
@@ -459,6 +459,8 @@ func registerBuiltinServices(registry *ServiceRegistry) {
 	registry.Register("gotifys", func() Service { return NewGotifyService() })
 	registry.Register("ntfy", func() Service { return NewNtfyService() })
 	registry.Register("ntfys", func() Service { return NewNtfyService() })
+	registry.Register("bark", func() Service { return NewBarkService() })
+	registry.Register("barks", func() Service { return NewBarkService() })
 
 	// Cloud services
 	registry.Register("sns", func() Service { return NewAWSSNSService() })

--- a/apprise/apprise.go
+++ b/apprise/apprise.go
@@ -406,6 +406,9 @@ func registerBuiltinServices(registry *ServiceRegistry) {
 
 	// Enterprise messaging
 	registry.Register("msteams", func() Service { return NewMSTeamsService() })
+	registry.Register("powerautomate", func() Service { return NewMSTeamsService() }) // Alias for Power Automate
+	registry.Register("workflows", func() Service { return NewMSTeamsService() })      // Alias for Workflows
+	registry.Register("msflow", func() Service { return NewMSTeamsService() })         // Alias for MS Flow (legacy name)
 	registry.Register("mattermost", func() Service { return NewMattermostService() })
 	registry.Register("mmosts", func() Service { return NewMattermostService() })
 	registry.Register("rocketchat", func() Service { return NewRocketChatService() })

--- a/apprise/bark.go
+++ b/apprise/bark.go
@@ -1,0 +1,249 @@
+package apprise
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// BarkService implements Bark iOS push notification service
+type BarkService struct {
+	deviceKey string
+	hostname  string
+	port      int
+	secure    bool // Use HTTPS (barks://) vs HTTP (bark://)
+
+	// Bark optional parameters
+	icon     string // Icon URL (new in v1.9.5)
+	sound    string // Sound name
+	badge    int    // Badge count
+	url      string // URL to open when tapped
+	category string // Notification category
+	group    string // Notification group
+
+	client *http.Client
+}
+
+// BarkPayload represents the Bark API request payload
+type BarkPayload struct {
+	Title    string `json:"title,omitempty"`
+	Body     string `json:"body"`
+	DeviceKey string `json:"device_key"`
+	Icon     string `json:"icon,omitempty"`      // Icon URL (v1.9.5+)
+	Sound    string `json:"sound,omitempty"`     // Sound name
+	Badge    int    `json:"badge,omitempty"`     // Badge count
+	URL      string `json:"url,omitempty"`       // Action URL
+	Category string `json:"category,omitempty"`  // Category
+	Group    string `json:"group,omitempty"`     // Group
+}
+
+// NewBarkService creates a new Bark service instance
+func NewBarkService() Service {
+	return &BarkService{
+		client: &http.Client{},
+		port:   -1, // Use default port based on scheme
+	}
+}
+
+// GetServiceID returns the service identifier
+func (b *BarkService) GetServiceID() string {
+	return "bark"
+}
+
+// GetDefaultPort returns the default port
+func (b *BarkService) GetDefaultPort() int {
+	if b.secure {
+		return 443
+	}
+	return 80
+}
+
+// ParseURL parses a Bark service URL
+// Format: bark://devicekey@hostname[:port]/
+// Format: barks://devicekey@hostname[:port]/?icon=url&sound=sound
+func (b *BarkService) ParseURL(serviceURL *url.URL) error {
+	// Check scheme
+	if serviceURL.Scheme == "barks" {
+		b.secure = true
+	} else if serviceURL.Scheme == "bark" {
+		b.secure = false
+	} else {
+		return fmt.Errorf("invalid scheme: expected 'bark' or 'barks', got '%s'", serviceURL.Scheme)
+	}
+
+	// Extract device key from user info
+	if serviceURL.User == nil || serviceURL.User.Username() == "" {
+		return fmt.Errorf("bark device key is required (format: bark://devicekey@hostname)")
+	}
+	b.deviceKey = serviceURL.User.Username()
+
+	// Extract hostname
+	b.hostname = serviceURL.Hostname()
+	if b.hostname == "" {
+		return fmt.Errorf("bark server hostname is required")
+	}
+
+	// Extract port if specified
+	if portStr := serviceURL.Port(); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			return fmt.Errorf("invalid port: %s", portStr)
+		}
+		b.port = port
+	}
+
+	// Parse query parameters
+	query := serviceURL.Query()
+
+	if icon := query.Get("icon"); icon != "" {
+		b.icon = icon
+	}
+
+	if sound := query.Get("sound"); sound != "" {
+		b.sound = sound
+	}
+
+	if badgeStr := query.Get("badge"); badgeStr != "" {
+		if badge, err := strconv.Atoi(badgeStr); err == nil {
+			b.badge = badge
+		}
+	}
+
+	if actionURL := query.Get("url"); actionURL != "" {
+		b.url = actionURL
+	}
+
+	if category := query.Get("category"); category != "" {
+		b.category = category
+	}
+
+	if group := query.Get("group"); group != "" {
+		b.group = group
+	}
+
+	return nil
+}
+
+// Send sends a notification via Bark
+func (b *BarkService) Send(ctx context.Context, req NotificationRequest) error {
+	// Build the Bark server URL
+	scheme := "http"
+	if b.secure {
+		scheme = "https"
+	}
+
+	port := b.port
+	if port == -1 {
+		port = b.GetDefaultPort()
+	}
+
+	var serverURL string
+	if (b.secure && port == 443) || (!b.secure && port == 80) {
+		// Use default port - omit from URL
+		serverURL = fmt.Sprintf("%s://%s/push", scheme, b.hostname)
+	} else {
+		serverURL = fmt.Sprintf("%s://%s:%d/push", scheme, b.hostname, port)
+	}
+
+	// Build payload
+	payload := BarkPayload{
+		DeviceKey: b.deviceKey,
+		Title:     req.Title,
+		Body:      req.Body,
+		Icon:      b.icon,
+		Sound:     b.sound,
+		Badge:     b.badge,
+		URL:       b.url,
+		Category:  b.category,
+		Group:     b.group,
+	}
+
+	// If no title, use body as message
+	if payload.Title == "" && payload.Body != "" {
+		payload.Title = payload.Body
+		payload.Body = ""
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Bark payload: %w", err)
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", serverURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("User-Agent", GetUserAgent())
+
+	// Send request
+	resp, err := b.client.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("failed to send Bark notification: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bark API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response to check for Bark-specific errors
+	var barkResp struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// Non-fatal - response was successful HTTP status
+		return nil
+	}
+
+	if err := json.Unmarshal(body, &barkResp); err != nil {
+		// Non-fatal - response was successful HTTP status
+		return nil
+	}
+
+	// Check Bark API response code (200 = success)
+	if barkResp.Code != 200 {
+		return fmt.Errorf("bark API returned error code %d: %s", barkResp.Code, barkResp.Message)
+	}
+
+	return nil
+}
+
+// TestURL validates a Bark service URL
+func (b *BarkService) TestURL(serviceURL string) error {
+	parsedURL, err := url.Parse(serviceURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL format: %w", err)
+	}
+
+	return b.ParseURL(parsedURL)
+}
+
+// SupportsAttachments returns false (Bark doesn't support file attachments)
+func (b *BarkService) SupportsAttachments() bool {
+	return false
+}
+
+// GetMaxBodyLength returns Bark's message length limit
+func (b *BarkService) GetMaxBodyLength() int {
+	return 4096 // Reasonable limit for push notifications
+}
+
+// Example usage and URL formats:
+// bark://devicekey@api.day.app/
+// bark://devicekey@api.day.app/?icon=https://example.com/icon.png
+// barks://devicekey@bark.example.com:8080/?sound=alarm&badge=5
+// bark://devicekey@localhost:8080/?url=https://example.com&category=news

--- a/apprise/bark_test.go
+++ b/apprise/bark_test.go
@@ -1,0 +1,416 @@
+package apprise
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBarkService_GetServiceID(t *testing.T) {
+	service := NewBarkService()
+	if service.GetServiceID() != "bark" {
+		t.Errorf("Expected service ID 'bark', got '%s'", service.GetServiceID())
+	}
+}
+
+func TestBarkService_GetDefaultPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		secure       bool
+		expectedPort int
+	}{
+		{"HTTP", false, 80},
+		{"HTTPS", true, 443},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &BarkService{secure: tt.secure}
+			if service.GetDefaultPort() != tt.expectedPort {
+				t.Errorf("Expected default port %d, got %d", tt.expectedPort, service.GetDefaultPort())
+			}
+		})
+	}
+}
+
+func TestBarkService_SupportsAttachments(t *testing.T) {
+	service := NewBarkService()
+	if service.SupportsAttachments() {
+		t.Error("Bark should not support attachments")
+	}
+}
+
+func TestBarkService_GetMaxBodyLength(t *testing.T) {
+	service := NewBarkService()
+	expected := 4096
+	if service.GetMaxBodyLength() != expected {
+		t.Errorf("Expected max body length %d, got %d", expected, service.GetMaxBodyLength())
+	}
+}
+
+func TestBarkService_ParseURL(t *testing.T) {
+	tests := []struct {
+		name             string
+		url              string
+		expectError      bool
+		expectedKey      string
+		expectedHost     string
+		expectedPort     int
+		expectedSecure   bool
+		expectedIcon     string
+		expectedSound    string
+		expectedBadge    int
+		expectedURL      string
+		expectedCategory string
+		expectedGroup    string
+	}{
+		{
+			name:           "Basic bark URL",
+			url:            "bark://devicekey@api.day.app/",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "api.day.app",
+			expectedPort:   -1,
+			expectedSecure: false,
+		},
+		{
+			name:           "Secure bark URL",
+			url:            "barks://devicekey@api.day.app/",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "api.day.app",
+			expectedPort:   -1,
+			expectedSecure: true,
+		},
+		{
+			name:           "With custom port",
+			url:            "bark://devicekey@localhost:8080/",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "localhost",
+			expectedPort:   8080,
+			expectedSecure: false,
+		},
+		{
+			name:           "With icon parameter",
+			url:            "bark://devicekey@api.day.app/?icon=https://example.com/icon.png",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "api.day.app",
+			expectedIcon:   "https://example.com/icon.png",
+			expectedSecure: false,
+		},
+		{
+			name:           "With sound parameter",
+			url:            "bark://devicekey@api.day.app/?sound=alarm",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "api.day.app",
+			expectedSound:  "alarm",
+			expectedSecure: false,
+		},
+		{
+			name:           "With badge parameter",
+			url:            "bark://devicekey@api.day.app/?badge=5",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "api.day.app",
+			expectedBadge:  5,
+			expectedSecure: false,
+		},
+		{
+			name:           "With URL parameter",
+			url:            "bark://devicekey@api.day.app/?url=https://example.com",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "api.day.app",
+			expectedURL:    "https://example.com",
+			expectedSecure: false,
+		},
+		{
+			name:             "With category and group",
+			url:              "bark://devicekey@api.day.app/?category=news&group=alerts",
+			expectError:      false,
+			expectedKey:      "devicekey",
+			expectedHost:     "api.day.app",
+			expectedCategory: "news",
+			expectedGroup:    "alerts",
+			expectedSecure:   false,
+		},
+		{
+			name:           "With all parameters",
+			url:            "bark://devicekey@api.day.app/?icon=https://example.com/icon.png&sound=alarm&badge=3&url=https://example.com&category=news&group=alerts",
+			expectError:    false,
+			expectedKey:    "devicekey",
+			expectedHost:   "api.day.app",
+			expectedIcon:   "https://example.com/icon.png",
+			expectedSound:  "alarm",
+			expectedBadge:  3,
+			expectedURL:    "https://example.com",
+			expectedCategory: "news",
+			expectedGroup:    "alerts",
+			expectedSecure: false,
+		},
+		{
+			name:        "Invalid scheme",
+			url:         "http://devicekey@api.day.app/",
+			expectError: true,
+		},
+		{
+			name:        "Missing device key",
+			url:         "bark://api.day.app/",
+			expectError: true,
+		},
+		{
+			name:        "Missing hostname",
+			url:         "bark://devicekey@/",
+			expectError: true,
+		},
+		{
+			name:        "Invalid port",
+			url:         "bark://devicekey@api.day.app:invalid/",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewBarkService().(*BarkService)
+			parsedURL, err := url.Parse(tt.url)
+			if err != nil {
+				if !tt.expectError {
+					t.Fatalf("Failed to parse URL: %v", err)
+				}
+				return
+			}
+
+			err = service.ParseURL(parsedURL)
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if service.deviceKey != tt.expectedKey {
+				t.Errorf("Expected device key '%s', got '%s'", tt.expectedKey, service.deviceKey)
+			}
+
+			if service.hostname != tt.expectedHost {
+				t.Errorf("Expected hostname '%s', got '%s'", tt.expectedHost, service.hostname)
+			}
+
+			if tt.expectedPort != 0 && service.port != tt.expectedPort {
+				t.Errorf("Expected port %d, got %d", tt.expectedPort, service.port)
+			}
+
+			if service.secure != tt.expectedSecure {
+				t.Errorf("Expected secure %v, got %v", tt.expectedSecure, service.secure)
+			}
+
+			if tt.expectedIcon != "" && service.icon != tt.expectedIcon {
+				t.Errorf("Expected icon '%s', got '%s'", tt.expectedIcon, service.icon)
+			}
+
+			if tt.expectedSound != "" && service.sound != tt.expectedSound {
+				t.Errorf("Expected sound '%s', got '%s'", tt.expectedSound, service.sound)
+			}
+
+			if tt.expectedBadge != 0 && service.badge != tt.expectedBadge {
+				t.Errorf("Expected badge %d, got %d", tt.expectedBadge, service.badge)
+			}
+
+			if tt.expectedURL != "" && service.url != tt.expectedURL {
+				t.Errorf("Expected URL '%s', got '%s'", tt.expectedURL, service.url)
+			}
+
+			if tt.expectedCategory != "" && service.category != tt.expectedCategory {
+				t.Errorf("Expected category '%s', got '%s'", tt.expectedCategory, service.category)
+			}
+
+			if tt.expectedGroup != "" && service.group != tt.expectedGroup {
+				t.Errorf("Expected group '%s', got '%s'", tt.expectedGroup, service.group)
+			}
+		})
+	}
+}
+
+func TestBarkService_TestURL(t *testing.T) {
+	service := NewBarkService()
+
+	validURLs := []string{
+		"bark://devicekey@api.day.app/",
+		"barks://devicekey@api.day.app/",
+		"bark://devicekey@localhost:8080/",
+		"bark://devicekey@api.day.app/?icon=https://example.com/icon.png",
+	}
+
+	for _, validURL := range validURLs {
+		if err := service.TestURL(validURL); err != nil {
+			t.Errorf("Valid URL %q should not error: %v", validURL, err)
+		}
+	}
+
+	invalidURLs := []string{
+		"http://devicekey@api.day.app/",
+		"bark://api.day.app/",
+		"not-a-url",
+	}
+
+	for _, invalidURL := range invalidURLs {
+		if err := service.TestURL(invalidURL); err == nil {
+			t.Errorf("Invalid URL %q should error", invalidURL)
+		}
+	}
+}
+
+func TestBarkService_Send(t *testing.T) {
+	// Create mock Bark server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request method
+		if r.Method != "POST" {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+
+		// Verify Content-Type
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		// Verify User-Agent
+		if !strings.Contains(r.Header.Get("User-Agent"), "Apprise-Go") {
+			t.Errorf("Expected User-Agent to contain Apprise-Go, got %s", r.Header.Get("User-Agent"))
+		}
+
+		// Verify path
+		if r.URL.Path != "/push" {
+			t.Errorf("Expected path /push, got %s", r.URL.Path)
+		}
+
+		// Parse and verify request body
+		var payload BarkPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Failed to decode request body: %v", err)
+		}
+
+		// Verify payload fields
+		if payload.DeviceKey != "testkey" {
+			t.Errorf("Expected device key 'testkey', got '%s'", payload.DeviceKey)
+		}
+
+		if payload.Title != "Test Alert" {
+			t.Errorf("Expected title 'Test Alert', got '%s'", payload.Title)
+		}
+
+		if payload.Body != "This is a test notification" {
+			t.Errorf("Expected body 'This is a test notification', got '%s'", payload.Body)
+		}
+
+		if payload.Icon != "https://example.com/icon.png" {
+			t.Errorf("Expected icon 'https://example.com/icon.png', got '%s'", payload.Icon)
+		}
+
+		if payload.Sound != "alarm" {
+			t.Errorf("Expected sound 'alarm', got '%s'", payload.Sound)
+		}
+
+		if payload.Badge != 5 {
+			t.Errorf("Expected badge 5, got %d", payload.Badge)
+		}
+
+		// Send success response
+		w.WriteHeader(http.StatusOK)
+		response := map[string]interface{}{
+			"code":    200,
+			"message": "success",
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Parse server URL
+	serverURL, _ := url.Parse(server.URL)
+
+	// Configure service
+	service := NewBarkService().(*BarkService)
+	service.deviceKey = "testkey"
+	service.hostname = serverURL.Hostname()
+	if portStr := serverURL.Port(); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err == nil {
+			service.port = port
+		}
+	}
+	service.icon = "https://example.com/icon.png"
+	service.sound = "alarm"
+	service.badge = 5
+
+	req := NotificationRequest{
+		Title:      "Test Alert",
+		Body:       "This is a test notification",
+		NotifyType: NotifyTypeInfo,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := service.Send(ctx, req)
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+}
+
+func TestBarkService_SendError(t *testing.T) {
+	// Create mock Bark server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		response := map[string]interface{}{
+			"code":    400,
+			"message": "invalid device key",
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Parse server URL
+	serverURL, _ := url.Parse(server.URL)
+
+	// Configure service
+	service := NewBarkService().(*BarkService)
+	service.deviceKey = "testkey"
+	service.hostname = serverURL.Hostname()
+	if portStr := serverURL.Port(); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err == nil {
+			service.port = port
+		}
+	}
+
+	req := NotificationRequest{
+		Title:      "Test",
+		Body:       "Test",
+		NotifyType: NotifyTypeInfo,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := service.Send(ctx, req)
+	if err == nil {
+		t.Error("Expected error for Bark API error response")
+	}
+
+	if !strings.Contains(err.Error(), "bark API returned error code") {
+		t.Errorf("Expected Bark API error message, got: %v", err)
+	}
+}

--- a/apprise/msteams.go
+++ b/apprise/msteams.go
@@ -47,9 +47,53 @@ func (m *MSTeamsService) GetDefaultPort() int {
 // Legacy format: msteams://token_a/token_b/token_c
 // Modern format: msteams://team_name/token_a/token_b/token_c
 // Version 3 format: msteams://team_name/token_a/token_b/token_c/token_d
+// Power Automate format: powerautomate://prod-XX.region.logic.azure.com/workflows/.../triggers/manual/paths/invoke?params
+// Workflows format: workflows://prod-XX.region.logic.azure.com/workflows/.../triggers/manual/paths/invoke
+// MS Flow format: msflow://prod-XX.region.logic.azure.com/workflows/.../triggers/manual/paths/invoke
 func (m *MSTeamsService) ParseURL(serviceURL *url.URL) error {
-	if serviceURL.Scheme != "msteams" {
-		return fmt.Errorf("invalid scheme: expected 'msteams', got '%s'", serviceURL.Scheme)
+	validSchemes := []string{"msteams", "powerautomate", "workflows", "msflow"}
+	validScheme := false
+	for _, scheme := range validSchemes {
+		if serviceURL.Scheme == scheme {
+			validScheme = true
+			break
+		}
+	}
+
+	if !validScheme {
+		return fmt.Errorf("invalid scheme: expected 'msteams', 'powerautomate', 'workflows', or 'msflow', got '%s'", serviceURL.Scheme)
+	}
+
+	// Check if this is a Power Automate/Workflows URL
+	// Format: powerautomate://prod-XX.region.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke
+	// We detect this by checking if the scheme is one of the Power Automate aliases
+	// and if the hostname contains logic.azure.com
+	if (serviceURL.Scheme == "powerautomate" || serviceURL.Scheme == "workflows" || serviceURL.Scheme == "msflow") {
+		// Construct full webhook URL from hostname and path
+		if serviceURL.Host == "" {
+			return fmt.Errorf("power Automate webhook URL requires hostname")
+		}
+
+		// Build the full webhook URL (use HTTPS)
+		m.webhookURL = fmt.Sprintf("https://%s%s", serviceURL.Host, serviceURL.Path)
+
+		// Handle query parameters
+		query := serviceURL.Query()
+
+		// Extract our control parameters
+		if includeImage := query.Get("image"); includeImage != "" {
+			m.includeImage = strings.ToLower(includeImage) == "yes" || strings.ToLower(includeImage) == "true"
+			// Remove image parameter from webhook URL query
+			query.Del("image")
+		}
+
+		// Add remaining query parameters to webhook URL (if any)
+		if len(query) > 0 {
+			m.webhookURL = fmt.Sprintf("%s?%s", m.webhookURL, query.Encode())
+		}
+
+		m.version = 4 // Use version 4 to indicate Power Automate/Workflows
+		return nil
 	}
 
 	// Extract tokens from path
@@ -115,6 +159,9 @@ func (m *MSTeamsService) buildWebhookURL() string {
 		// Version 3 with additional token
 		return fmt.Sprintf("https://%s.webhook.office.com/webhookb2/%s/IncomingWebhook/%s/%s/%s",
 			m.teamName, m.tokenA, m.tokenB, m.tokenC, m.tokenD)
+	case 4:
+		// Version 4: Power Automate/Workflows - URL already set in ParseURL
+		return m.webhookURL
 	default:
 		return ""
 	}
@@ -482,3 +529,6 @@ func (m *MSTeamsService) getEmojiForNotifyType(notifyType NotifyType) string {
 // msteams://team_name/token_a/token_b/token_c/token_d (version 3)
 // msteams://token_a/token_b/token_c (legacy)
 // msteams://team_name/token_a/token_b/token_c?image=no
+// powerautomate://prod-XX.region.logic.azure.com:443/workflows/.../triggers/manual/paths/invoke?params
+// workflows://prod-XX.region.logic.azure.com/workflows/.../triggers/manual/paths/invoke
+// msflow://prod-XX.region.logic.azure.com/workflows/.../triggers/manual/paths/invoke

--- a/apprise/msteams_test.go
+++ b/apprise/msteams_test.go
@@ -316,3 +316,128 @@ func containsString(s, substr string) bool {
 	}
 	return false
 }
+
+func TestMSTeamsService_PowerAutomate_ParseURL(t *testing.T) {
+	testCases := []struct {
+		name            string
+		url             string
+		expectError     bool
+		expectedVersion int
+		expectedWebhook string
+	}{
+		{
+			name:            "Power Automate format",
+			url:             "powerautomate://prod-01.eastus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=xyz789",
+			expectError:     false,
+			expectedVersion: 4,
+			expectedWebhook: "https://prod-01.eastus.logic.azure.com:443/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-10-01&sig=xyz789&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0",
+		},
+		{
+			name:            "Workflows format",
+			url:             "workflows://prod-02.westus.logic.azure.com/workflows/def456/triggers/manual/paths/invoke",
+			expectError:     false,
+			expectedVersion: 4,
+			expectedWebhook: "https://prod-02.westus.logic.azure.com/workflows/def456/triggers/manual/paths/invoke",
+		},
+		{
+			name:            "MS Flow format",
+			url:             "msflow://prod-03.centralus.logic.azure.com:443/workflows/ghi789/triggers/manual/paths/invoke",
+			expectError:     false,
+			expectedVersion: 4,
+			expectedWebhook: "https://prod-03.centralus.logic.azure.com:443/workflows/ghi789/triggers/manual/paths/invoke",
+		},
+		{
+			name:            "Power Automate with image parameter",
+			url:             "powerautomate://prod-01.eastus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke?image=no&api-version=2016-10-01",
+			expectError:     false,
+			expectedVersion: 4,
+			expectedWebhook: "https://prod-01.eastus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-10-01",
+		},
+		{
+			name:        "Power Automate missing hostname",
+			url:         "powerautomate:///workflows/abc123/triggers/manual/paths/invoke",
+			expectError: true,
+		},
+		{
+			name:        "Invalid scheme",
+			url:         "invalidscheme://prod-01.eastus.logic.azure.com/workflows/abc123",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := NewMSTeamsService().(*MSTeamsService)
+			parsedURL, err := url.Parse(tc.url)
+			if err != nil {
+				t.Fatalf("Failed to parse URL: %v", err)
+			}
+
+			err = service.ParseURL(parsedURL)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if service.version != tc.expectedVersion {
+				t.Errorf("Expected version %d, got %d", tc.expectedVersion, service.version)
+			}
+
+			if tc.expectedWebhook != "" && service.webhookURL != tc.expectedWebhook {
+				t.Errorf("Expected webhook URL '%s', got '%s'", tc.expectedWebhook, service.webhookURL)
+			}
+		})
+	}
+}
+
+func TestMSTeamsService_PowerAutomate_TestURL(t *testing.T) {
+	service := NewMSTeamsService()
+
+	validURLs := []string{
+		"powerautomate://prod-01.eastus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke",
+		"workflows://prod-02.westus.logic.azure.com:443/workflows/def456/triggers/manual/paths/invoke",
+		"msflow://prod-03.centralus.logic.azure.com/workflows/ghi789/triggers/manual/paths/invoke",
+	}
+
+	for _, testURL := range validURLs {
+		t.Run("Valid_"+testURL, func(t *testing.T) {
+			err := service.TestURL(testURL)
+			if err != nil {
+				t.Errorf("Expected valid URL %s to pass, got error: %v", testURL, err)
+			}
+		})
+	}
+
+	invalidURLs := []string{
+		"powerautomate:///workflows/abc123", // Missing hostname
+		"workflows:///invalid",               // Missing hostname
+	}
+
+	for _, testURL := range invalidURLs {
+		t.Run("Invalid_"+testURL, func(t *testing.T) {
+			err := service.TestURL(testURL)
+			if err == nil {
+				t.Errorf("Expected invalid URL %s to fail", testURL)
+			}
+		})
+	}
+}
+
+func TestMSTeamsService_PowerAutomate_BuildWebhookURL(t *testing.T) {
+	service := NewMSTeamsService().(*MSTeamsService)
+	service.version = 4
+	expectedURL := "https://prod-01.eastus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke"
+	service.webhookURL = expectedURL
+
+	actualURL := service.buildWebhookURL()
+	if actualURL != expectedURL {
+		t.Errorf("Expected URL '%s', got '%s'", expectedURL, actualURL)
+	}
+}


### PR DESCRIPTION
## Summary
Implements Power Automate (formerly Microsoft Flow) and Workflows support by extending the MS Teams service to handle Azure Logic Apps webhook URLs.

## Changes
- ✅ Extended MSTeamsService to accept full Logic Apps webhook URLs
- ✅ Added three URL scheme aliases: `powerautomate://`, `workflows://`, `msflow://`
- ✅ Version 4 webhook URL handling
- ✅ Backward compatible with existing Teams URL formats
- ✅ Comprehensive test coverage (3 new test functions, 12 test cases)
- ✅ Full documentation in USAGE.md with examples
- ✅ Updated README.md

## URL Formats
```
# Power Automate
powerautomate://prod-01.eastus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke?params

# Workflows
workflows://prod-02.westus.logic.azure.com/workflows/def456/triggers/manual/paths/invoke

# MS Flow (legacy)
msflow://prod-03.centralus.logic.azure.com/workflows/ghi789/triggers/manual/paths/invoke
```

## Technical Details
- Uses same MessageCard format as Teams webhooks
- Constructs HTTPS URL from scheme + hostname + path
- Preserves original webhook query parameters
- Filters out control parameters (e.g., `image=yes/no`)
- Version 4 designation for Power Automate URLs

## Tests
All MS Teams tests passing (21/21):
```
✅ TestMSTeamsService_PowerAutomate_ParseURL (6 test cases)
   - Power Automate format with query parameters
   - Workflows format
   - MS Flow format
   - Image parameter filtering
   - Missing hostname validation
   - Invalid scheme validation

✅ TestMSTeamsService_PowerAutomate_TestURL (5 test cases)
   - Valid URLs for all three schemes
   - Invalid URL validation

✅ TestMSTeamsService_PowerAutomate_BuildWebhookURL
   - Version 4 webhook URL construction
```

## Example Usage
```go
app := apprise.New()

// Power Automate
app.Add("powerautomate://prod-01.eastus.logic.azure.com/workflows/abc123/triggers/manual/paths/invoke?api-version=2016-10-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=xyz789")

// Workflows
app.Add("workflows://prod-02.westus.logic.azure.com/workflows/def456/triggers/manual/paths/invoke")

// MS Flow (legacy)
app.Add("msflow://prod-03.centralus.logic.azure.com/workflows/ghi789/triggers/manual/paths/invoke")

app.Notify("Automation Alert", "Workflow triggered successfully", apprise.NotifyTypeSuccess)
```

## Documentation
### USAGE.md
- New Power Automate / Workflows section under MS Teams
- URL format examples
- Getting webhook URL instructions
- Code examples

### README.md
- Updated MS Teams entry to mention Power Automate support

## Resolves
Closes #4

## Milestone
v1.9.5-1